### PR TITLE
Input for munin-node data sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ if (SQLITE3)
         metadata_writer_sqlite.c
         metadata_writer_sqlite_helpers.c
         metadata_writer_sqlite_conn.c
-        metadata_writer_sqlite_gps.c)
+        metadata_writer_sqlite_gps.c
+        metadata_writer_sqlite_monitor.c)
     add_definitions("-DSQLITE_SUPPORT")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,12 @@ if (GPSD)
     add_definitions("-DGPSD_SUPPORT")
 endif()
 
+if (MUNIN)
+    set(SOURCE ${SOURCE}
+        metadata_input_munin.c)
+    add_definitions("-DMUNIN_SUPPORT")
+endif()
+
 if (GPS_NSB)
     set(SOURCE ${SOURCE}
         metadata_input_gps_nsb.c)

--- a/metadata_exporter.c
+++ b/metadata_exporter.c
@@ -119,6 +119,16 @@ void mde_start_timer(struct backend_event_loop *event_loop,
     backend_insert_timeout(event_loop, timeout_handle);
 }
 
+//TODO: Find a place to catch termination signals, and call this.
+void mde_destroy(struct md_exporter *mde) 
+{
+    int i;
+    for (i=0; i<=MD_INPUT_MAX; i++) 
+        if (mde->md_inputs[i] != NULL) 
+            if (mde->md_inputs[i]->destroy != NULL) 
+                mde->md_inputs[i]->destroy(mde->md_inputs[i]);
+}
+
 static int configure_core(struct md_exporter **mde)
 {
     //Configure core variables

--- a/metadata_exporter.c
+++ b/metadata_exporter.c
@@ -43,6 +43,9 @@
 #ifdef GPSD_SUPPORT
     #include "metadata_input_gpsd.h"
 #endif
+#ifdef MUNIN_SUPPORT
+    #include "metadata_input_munin.h"
+#endif
 #ifdef NSB_GPS
     #include "metadata_input_gps_nsb.h"
 #endif
@@ -61,6 +64,7 @@
 #include "backend_event_loop.h"
 
 struct md_input_gpsd;
+struct md_input_munin;
 struct md_writer_sqlite;
 struct md_writer_zeromq;
 
@@ -450,7 +454,7 @@ static void run_test_mode(struct md_exporter *mde, uint32_t packets)
 
 static void default_usage()
 {
-    fprintf(stderr, "Support paramteres (r is required). At least one input and one writer must be specified.\n");
+    fprintf(stderr, "Support parameters (r is required). At least one input and one writer must be specified.\n");
     fprintf(stderr, "Default:\n");
     fprintf(stderr, "--netlink/-n: netlink input\n");
 #ifdef NSB_GPS
@@ -458,6 +462,9 @@ static void default_usage()
 #endif
 #ifdef GPSD_SUPPORT
     fprintf(stderr, "--gpsd/-g: gpsd input\n");
+#endif
+#ifdef MUNIN_SUPPORT
+    fprintf(stderr, "--munin/-m: munin input\n");
 #endif
 #ifdef SQLITE_SUPPORT
     fprintf(stderr, "--sqlite/-s: sqlite writer\n");
@@ -516,6 +523,9 @@ int main(int argc, char *argv[])
 #ifdef GPSD_SUPPORT
         {"gpsd",         no_argument,        0,  'g'},
 #endif
+#ifdef MUNIN_SUPPORT
+        {"munin",         no_argument,       0,  'm'},
+#endif
         {"packets",      required_argument,  0,  'p'},
         {"test",         no_argument,        0,  't'},
         {"help",         no_argument,        0,  'h'},
@@ -530,7 +540,7 @@ int main(int argc, char *argv[])
     opterr = 0;
     while (1) {
         //Use glic extension to avoid getopt permuting array while processing
-        i = getopt_long(argc, argv, "--szhgtnp:", core_options, &option_index);
+        i = getopt_long(argc, argv, "--szhgmtnp:", core_options, &option_index);
 
         if (i == -1)
             break;
@@ -582,11 +592,24 @@ int main(int argc, char *argv[])
             mde->md_inputs[MD_INPUT_GPSD] = calloc(sizeof(struct md_input_gpsd), 1);
 
             if (mde->md_inputs[MD_INPUT_GPSD] == NULL) {
-                fprintf(stderr, "Could not allocate Netlink input\n");
+                fprintf(stderr, "Could not allocate GPSD input\n");
                 exit(EXIT_FAILURE);
             }
 
             md_gpsd_setup(mde, (struct md_input_gpsd*) mde->md_inputs[MD_INPUT_GPSD]);
+            num_inputs++;
+            break;
+#endif
+#ifdef MUNIN_SUPPORT
+        case 'm':
+            mde->md_inputs[MD_INPUT_MUNIN] = calloc(sizeof(struct md_input_munin), 1);
+
+            if (mde->md_inputs[MD_INPUT_MUNIN] == NULL) {
+                fprintf(stderr, "Could not allocate Munin input\n");
+                exit(EXIT_FAILURE);
+            }
+
+            md_munin_setup(mde, (struct md_input_munin*) mde->md_inputs[MD_INPUT_MUNIN]);
             num_inputs++;
             break;
 #endif

--- a/metadata_exporter.h
+++ b/metadata_exporter.h
@@ -100,7 +100,8 @@ enum md_writers {
     void (*usage)()
 
 #define MD_EVENT \
-    uint32_t md_type
+    uint32_t md_type; \
+    uint16_t sequence
 
 struct mnl_socket;
 struct backend_event_loop;
@@ -129,7 +130,6 @@ struct md_conn_event {
     uint32_t network_provider;
     const char *network_address;
     const char *event_value_str;
-    uint16_t sequence;
 };
 
 struct md_gps_event {
@@ -142,7 +142,6 @@ struct md_gps_event {
     float speed;
     float altitude;
     int satellites_tracked;
-    uint16_t sequence;
     uint8_t minmea_id;
 };
 

--- a/metadata_exporter.h
+++ b/metadata_exporter.h
@@ -30,6 +30,8 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include JSON_LOC
+
 #include "lib/minmea.h"
 
 #define MDE_VERSION 1
@@ -41,6 +43,7 @@
 #define META_TYPE_INTERFACE  0x01
 #define META_TYPE_CONNECTION 0x02
 #define META_TYPE_POS        0x04
+#define META_TYPE_MUNIN      0x05
 
 enum conn_event {
     CONN_EVENT_L3_UP=1,
@@ -73,6 +76,7 @@ enum md_inputs {
     MD_INPUT_NETLINK,
     MD_INPUT_GPSD,
     MD_INPUT_GPS_NSB,
+    MD_INPUT_MUNIN,
     __MD_INPUT_MAX
 };
 
@@ -140,6 +144,12 @@ struct md_gps_event {
     int satellites_tracked;
     uint16_t sequence;
     uint8_t minmea_id;
+};
+
+struct md_munin_event {
+    MD_EVENT;
+    int64_t tstamp;
+    json_object* json_blob;
 };
 
 struct md_exporter {

--- a/metadata_exporter.h
+++ b/metadata_exporter.h
@@ -90,6 +90,7 @@ enum md_writers {
 #define MD_INPUT \
     struct md_exporter *parent; \
     uint8_t (*init)(void *ptr, int argc, char *argv[]); \
+    void (*destroy)(void *ptr); \
     void (*usage)()
 
 #define MD_WRITER \

--- a/metadata_input_munin.c
+++ b/metadata_input_munin.c
@@ -166,6 +166,7 @@ static void md_input_munin_handle_event(void *ptr, int32_t fd, uint32_t events)
 
     munin_event.md_type   = META_TYPE_MUNIN;
     munin_event.tstamp    = tv.tv_sec;
+    munin_event.sequence  = mde_inc_seq(mim->parent);
     munin_event.json_blob = blob;
 
     //fprintf(stderr, "JSON dump: %s\n", json_object_to_json_string(blob));

--- a/metadata_input_munin.c
+++ b/metadata_input_munin.c
@@ -177,6 +177,7 @@ static void md_input_munin_handle_event(void *ptr, int32_t fd, uint32_t events)
 
     //fprintf(stderr, "JSON dump: %s\n", json_object_to_json_string(blob));
     mde_publish_event_obj(mim->parent, (struct md_event *) &munin_event);
+    json_object_put(blob);
 }
 
 static uint8_t md_munin_config(struct md_input_munin *mim,

--- a/metadata_input_munin.c
+++ b/metadata_input_munin.c
@@ -235,6 +235,15 @@ static uint8_t md_munin_config(struct md_input_munin *mim,
     }
 }
 
+static uint8_t md_input_munin_destroy(void *ptr) 
+{
+    struct md_input_munin *mim = ptr;
+    if ((mim != NULL) && (mim->module_count > 0)) { 
+      free(mim->modules);
+      mim->module_count = 0;
+    }
+}
+
 static uint8_t md_input_munin_init(void *ptr, int argc, char *argv[])
 {
     struct md_input_munin *mim = ptr;
@@ -284,7 +293,8 @@ static void md_munin_usage()
 
 void md_munin_setup(struct md_exporter *mde, struct md_input_munin *mim)
 {
-    mim->parent = mde;
-    mim->init   = md_input_munin_init;
-    mim->usage  = md_munin_usage;
+    mim->parent  = mde;
+    mim->init    = md_input_munin_init;
+    mim->destroy = md_input_munin_destroy;
+    mim->usage   = md_munin_usage;
 }

--- a/metadata_input_munin.c
+++ b/metadata_input_munin.c
@@ -1,0 +1,264 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/time.h>
+#include <sys/timerfd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <errno.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include "metadata_exporter.h"
+#include "metadata_input_munin.h"
+#include "backend_event_loop.h"
+
+/* polling interval in seconds */
+#define MUNIN_POLLING_INTERVAL 5  
+
+/* TODO
+- handle socket disconnect/reconnect 
+*/
+ssize_t readLine(int fd, void *buffer, size_t n)
+{
+    ssize_t numRead;                   
+    size_t totRead;                  
+    char *buf;
+    char ch;
+
+    if (n <= 0 || buffer == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    buf = buffer;     
+
+    totRead = 0;
+    for (;;) {
+        numRead = read(fd, &ch, 1);
+
+        if (numRead == -1) {
+            if (errno == EINTR)    
+                continue;
+            else
+                return -1;         
+
+        } else if (numRead == 0) {      
+            if (totRead == 0)          
+                return 0;
+            else                     
+                break;
+
+        } else {                       
+            if (totRead < n - 1) {  
+                totRead++;
+                *buf++ = ch;
+            }
+
+            if (ch == '\n')
+                break;
+        }
+    }
+
+    *buf = '\0';
+    return totRead;
+}
+
+uint8_t reconnect (struct md_input_munin *mim, const char *address, const char *port) {
+    int n = -1;
+    char buffer[256] = "\n";
+    struct hostent* server;
+    struct sockaddr_in serv_addr;
+
+    if ((mim->munin_socket_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+      fprintf(stderr, "Error opening socket.\n");
+      return RETVAL_FAILURE;
+    }
+    if ((server = gethostbyname(address)) == NULL) {
+      fprintf(stderr, "No such host: %s\n", address);
+      return RETVAL_FAILURE;
+    }
+    
+    bzero((char *) &serv_addr, sizeof(serv_addr));
+    serv_addr.sin_family = AF_INET;
+    bcopy((char *)server->h_addr, (char *)&serv_addr.sin_addr.s_addr, server->h_length);
+    serv_addr.sin_port = htons(atoi(port));
+  
+    if (connect(mim->munin_socket_fd,(struct sockaddr *)&serv_addr,sizeof(serv_addr)) < 0) {
+      fprintf(stderr, "Could not connect to munin.");
+      return RETVAL_FAILURE;
+    } 
+    
+    if ((n = readLine(mim->munin_socket_fd, buffer, 255))<0) {
+      fprintf(stderr, "Could not read munin welcome string.");
+      close(mim->munin_socket_fd);
+      return RETVAL_FAILURE;
+    }
+    printf("%s", buffer);
+    
+    return RETVAL_SUCCESS;
+}
+
+void json_add_key_value(char* kv, json_object* blob) {
+  char *running = kv;
+  // a munin string is in the form uptime.value 1.23
+  char *key     = strsep(&running, ".");
+  strsep(&running, " "); //ignore .value
+  char *value   = strsep(&running, "\n");
+  
+
+  struct json_object *obj_add = NULL;
+  if ((obj_add = json_object_new_string(value))==NULL) 
+    return;
+  json_object_object_add(blob, key, obj_add);
+}
+
+static void md_input_munin_handle_event(void *ptr, int32_t fd, uint32_t events)
+{
+    struct md_input_munin *mim = ptr;
+    int i,n;
+    uint64_t exp;
+
+    if ((n=read(fd, &exp, sizeof(uint64_t))) < sizeof(uint64_t)) {
+        fprintf(stderr, "Munin timer failed.\n");
+        return;
+    }
+     
+    setsockopt( mim->munin_socket_fd, IPPROTO_TCP, TCP_NODELAY, (void *)&i, sizeof(i));
+
+    struct json_object *blob = NULL;
+    struct timeval tv;
+
+    if (!(blob = json_object_new_object()))
+        return;
+
+    const char* const modules[] = {
+      "uptime",
+      "cpu",
+      "memory",
+    }; 
+    int nmodules = 3;
+
+    for (i=0; i<nmodules; i++) {
+      char cmd[256];
+      char buffer[256];
+      snprintf(cmd, 255, "fetch %s\n", modules[i]);
+
+      if ((n=write(mim->munin_socket_fd, cmd, strlen(cmd)))<0) {
+          fprintf(stderr, "Writing to munin failed.\n");
+          return;
+      }
+
+      struct json_object *obj_mod = NULL;
+      if (!(obj_mod = json_object_new_object()))
+        break;
+      json_object_object_add(blob, modules[i], obj_mod);
+
+      while (1) {
+        if ((n=readLine(mim->munin_socket_fd, buffer, 255))<0) {
+            fprintf(stderr, "Reading from munin failed.\n");
+            return;
+        }
+        if ((buffer[0] == '#') || (buffer[0] == '.')) 
+          break;
+        json_add_key_value(buffer, obj_mod);
+      }
+    }
+       
+    struct md_munin_event munin_event;
+    memset(&munin_event, 0, sizeof(struct md_munin_event));
+    gettimeofday(&tv, NULL);
+
+    munin_event.md_type   = META_TYPE_MUNIN;
+    munin_event.tstamp    = tv.tv_sec;
+    munin_event.json_blob = blob;
+
+    //fprintf(stderr, "JSON dump: %s\n", json_object_to_json_string(blob));
+    mde_publish_event_obj(mim->parent, (struct md_event *) &munin_event);
+}
+
+static uint8_t md_munin_config(struct md_input_munin *mim,
+                              const char *address,
+                              const char *port)
+{
+    int timer;
+    struct itimerspec delay;
+
+    if (reconnect(mim, address, port) == RETVAL_SUCCESS) {
+      if ((timer = timerfd_create(CLOCK_REALTIME, 0)) < 0) {
+        fprintf(stderr, "Could not create munin polling timer.");
+        return RETVAL_FAILURE;
+      }
+      
+      delay.it_value.tv_sec     = MUNIN_POLLING_INTERVAL;
+      delay.it_value.tv_nsec    = 0;
+      delay.it_interval.tv_sec  = MUNIN_POLLING_INTERVAL;
+      delay.it_interval.tv_nsec = 0;
+      if (timerfd_settime(timer, TFD_TIMER_ABSTIME, &delay, NULL) < 0) {
+        fprintf(stderr, "Could not initialize munin polling timer.");
+        return RETVAL_FAILURE;
+      }
+
+      if(!(mim->event_handle = backend_create_epoll_handle(
+                               mim, timer, md_input_munin_handle_event)))
+        return RETVAL_FAILURE;
+
+      backend_event_loop_update(
+          mim->parent->event_loop, EPOLLIN, EPOLL_CTL_ADD, timer, mim->event_handle);
+
+      return RETVAL_SUCCESS;
+    } else {
+      return RETVAL_FAILURE;
+    }
+}
+
+static uint8_t md_input_munin_init(void *ptr, int argc, char *argv[])
+{
+    struct md_input_munin *mim = ptr;
+    const char *address = NULL, *port = NULL;
+    int c, option_index = 0;
+
+    static struct option munin_options[] = {
+        {"munin_address",         required_argument,  0,  0},
+        {"munin_port",            required_argument,  0,  0},
+        {0,                                      0,  0,  0}};
+
+    while (1) {
+        //No permuting of array here as well
+        c = getopt_long_only(argc, argv, "--", munin_options, &option_index);
+
+        if (c == -1)
+            break;
+        else if (c)
+            continue;
+
+        if (!strcmp(munin_options[option_index].name, "munin_address"))
+            address = optarg;
+        else if (!strcmp(munin_options[option_index].name, "munin_port"))
+            port = optarg;
+    }
+
+    if (address == NULL || port == NULL) {
+        fprintf(stderr, "Missing required Munin argument\n");
+        return RETVAL_FAILURE;
+    }
+
+    return md_munin_config(mim, address, port);
+}
+
+static void md_munin_usage()
+{
+    fprintf(stderr, "Munin input:\n");
+    // TODO: --munin-binary (no need to run systemd, nginx or inetd)
+    fprintf(stderr, "--munin_address: munin address (r)\n");
+    fprintf(stderr, "--munin_port:    munin port    (r)\n");
+}
+
+void md_munin_setup(struct md_exporter *mde, struct md_input_munin *mim)
+{
+    mim->parent = mde;
+    mim->init   = md_input_munin_init;
+    mim->usage  = md_munin_usage;
+}

--- a/metadata_input_munin.c
+++ b/metadata_input_munin.c
@@ -118,7 +118,7 @@ void json_add_key_value(char* kv, json_object* blob) {
 static void md_input_munin_handle_event(void *ptr, int32_t fd, uint32_t events)
 {
     struct md_input_munin *mim = ptr;
-    int i,n;
+    int i=0,n;
     uint64_t exp;
 
     if ((n=read(fd, &exp, sizeof(uint64_t))) < sizeof(uint64_t)) {

--- a/metadata_input_munin.h
+++ b/metadata_input_munin.h
@@ -1,0 +1,18 @@
+#ifndef METADATA_INPUT_MUNIN_H
+#define METADATA_INPUT_MUNIN_H
+
+#include <uv.h>
+
+#include "metadata_exporter.h"
+
+struct backend_epoll_handle;
+
+struct md_input_munin {
+    MD_INPUT;
+    struct backend_epoll_handle *event_handle;
+    int munin_socket_fd;
+};
+
+void md_munin_setup(struct md_exporter *mde, struct md_input_munin *mim);
+
+#endif

--- a/metadata_input_munin.h
+++ b/metadata_input_munin.h
@@ -11,6 +11,8 @@ struct md_input_munin {
     MD_INPUT;
     struct backend_epoll_handle *event_handle;
     int munin_socket_fd;
+    int module_count; 
+    char** modules; 
 };
 
 void md_munin_setup(struct md_exporter *mde, struct md_input_munin *mim);

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -39,6 +39,7 @@
 #include "metadata_writer_sqlite_conn.h"
 #include "metadata_writer_sqlite_helpers.h"
 #include "metadata_writer_sqlite_gps.h"
+#include "metadata_writer_sqlite_monitor.h"
 #include "netlink_helpers.h"
 #include "system_helpers.h"
 #include "backend_event_loop.h"
@@ -73,9 +74,10 @@ static void md_sqlite_copy_db(struct md_writer_sqlite *mws, uint8_t from_timeout
         mws->timeout_added = 0;
     }
 
-    META_PRINT(mws->parent->logfile, "Will export DB. # meta %u # gps %u\n",
+    META_PRINT(mws->parent->logfile, "Will export DB. # meta %u # gps %u # monitor %u\n",
             mws->num_conn_events,
-            mws->num_gps_events);
+            mws->num_gps_events,
+            mws->num_munin_events);
 
     if (mws->num_conn_events) {
         retval = md_sqlite_conn_copy_db(mws);
@@ -86,6 +88,13 @@ static void md_sqlite_copy_db(struct md_writer_sqlite *mws, uint8_t from_timeout
 
     if (mws->num_gps_events) {
         retval = md_sqlite_gps_copy_db(mws);
+
+        if (retval == RETVAL_FAILURE)
+            num_failed++;
+    }
+
+    if (mws->num_munin_events) {
+        retval = md_sqlite_monitor_copy_db(mws);
 
         if (retval == RETVAL_FAILURE)
             num_failed++;
@@ -165,12 +174,19 @@ static sqlite3* md_sqlite_configure_db(struct md_writer_sqlite *mws, const char 
         return NULL;
     }
 
+    if (sqlite3_exec(db_handle, CREATE_MONITOR_SQL, NULL, NULL, &db_errmsg)) {
+        META_PRINT(mws->parent->logfile, "db create (monitor) failed with message: %s\n", db_errmsg);
+        sqlite3_close_v2(db_handle);
+        return NULL;
+    }
+
     return db_handle;
 }
 
 static int md_sqlite_configure(struct md_writer_sqlite *mws,
         const char *db_filename, uint32_t node_id, uint32_t db_interval,
-        uint32_t db_events, const char *meta_prefix, const char *gps_prefix)
+        uint32_t db_events, const char *meta_prefix, const char *gps_prefix,
+        const char *monitor_prefix)
 {
     sqlite3 *db_handle = md_sqlite_configure_db(mws, db_filename);
    
@@ -210,7 +226,13 @@ static int md_sqlite_configure(struct md_writer_sqlite *mws,
        sqlite3_prepare_v2(mws->db_handle, DELETE_GPS_TABLE, -1,
             &(mws->delete_gps), NULL) ||
        sqlite3_prepare_v2(mws->db_handle, DUMP_GPS, -1,
-            &(mws->dump_gps), NULL)){
+            &(mws->dump_gps), NULL) ||
+       sqlite3_prepare_v2(mws->db_handle, INSERT_MONITOR_EVENT, -1,
+            &(mws->insert_monitor), NULL) ||
+       sqlite3_prepare_v2(mws->db_handle, DELETE_MONITOR_TABLE, -1,
+            &(mws->delete_monitor), NULL) ||
+       sqlite3_prepare_v2(mws->db_handle, DUMP_MONITOR, -1,
+            &(mws->dump_monitor), NULL)) {
         META_PRINT(mws->parent->logfile, "Statement failed: %s\n", sqlite3_errmsg(mws->db_handle));
         sqlite3_close_v2(db_handle);
         return RETVAL_FAILURE;
@@ -234,6 +256,15 @@ static int md_sqlite_configure(struct md_writer_sqlite *mws,
         mws->gps_prefix_len = strlen(gps_prefix);
     }
 
+    if (monitor_prefix) {
+        memset(mws->monitor_prefix, 0, sizeof(mws->monitor_prefix));
+        memcpy(mws->monitor_prefix, monitor_prefix, strlen(monitor_prefix));
+
+        //We need to reset the last six characthers to X, so keep track of the
+        //length of the original prefix
+        mws->monitor_prefix_len = strlen(monitor_prefix);
+    }
+
     if (mws->node_id && (md_sqlite_update_nodeid_db(mws, UPDATE_EVENT_ID) ||
         md_sqlite_update_nodeid_db(mws, UPDATE_UPDATES_ID))) {
         META_PRINT(mws->parent->logfile, "Could not update old ements with id 0\n");
@@ -250,6 +281,7 @@ static void md_sqlite_usage()
     fprintf(stderr, "--sql_nodeid: node id. If not specified, will be read from system (compile option)\n");
     fprintf(stderr, "--sql_meta_prefix: location + filename prefix for connection metadata ( max 116 characters)\n");
     fprintf(stderr, "--sql_gps_prefix: location + filename prefix for GPS data (max 116 characters)\n");
+    fprintf(stderr, "--sql_monitor_prefix: location + filename prefix for monitor data (max 116 characters)\n");
     fprintf(stderr, "--sql_interval: time (in ms) from event and until database is copied (default: 5 sec)\n");
     fprintf(stderr, "--sql_events: number of events before copying database\n (default: 10)\n");
 }
@@ -259,13 +291,15 @@ int32_t md_sqlite_init(void *ptr, int argc, char *argv[])
     struct md_writer_sqlite *mws = ptr;
     uint32_t node_id = 0, interval = DEFAULT_TIMEOUT, num_events = EVENT_LIMIT;
     int c, option_index = 0;
-    const char *db_filename = NULL, *meta_prefix = NULL, *gps_prefix = NULL;
+    const char *db_filename = NULL, *meta_prefix = NULL, *gps_prefix = NULL,
+               *monitor_prefix = NULL;
 
     static struct option sqlite_options[] = {
         {"sql_database",         required_argument,  0,  0},
         {"sql_nodeid",           required_argument,  0,  0},
         {"sql_meta_prefix",      required_argument,  0,  0},
         {"sql_gps_prefix",       required_argument,  0,  0},
+        {"sql_monitor_prefix",   required_argument,  0,  0},
         {"sql_interval",         required_argument,  0,  0},
         {"sql_events",           required_argument,  0,  0},
         {0,                                      0,  0,  0}};
@@ -287,19 +321,22 @@ int32_t md_sqlite_init(void *ptr, int argc, char *argv[])
             meta_prefix = optarg;
         else if (!strcmp(sqlite_options[option_index].name, "sql_gps_prefix"))
             gps_prefix = optarg;
+        else if (!strcmp(sqlite_options[option_index].name, "sql_monitor_prefix"))
+            monitor_prefix = optarg;
         else if (!strcmp(sqlite_options[option_index].name, "sql_interval"))
             interval = ((uint32_t) atoi(optarg)) * 1000;
         else if (!strcmp(sqlite_options[option_index].name, "sql_events"))
             num_events = (uint32_t) atoi(optarg);
     }
 
-    if (!db_filename || (!gps_prefix && !meta_prefix)) {
+    if (!db_filename || (!gps_prefix && !meta_prefix && !monitor_prefix)) {
         META_PRINT(mws->parent->logfile, "Required SQLite argument missing\n");
         return RETVAL_FAILURE;
     }
 
-    if ((meta_prefix && strlen(meta_prefix) > 117) ||
-        (gps_prefix && strlen(gps_prefix) > 117)) {
+    if ((meta_prefix    && strlen(meta_prefix)    > 117) ||
+        (gps_prefix     && strlen(gps_prefix)     > 117) ||
+        (monitor_prefix && strlen(monitor_prefix) > 117)) {
         META_PRINT(mws->parent->logfile, "SQLite temp file prefix too long\n");
         return RETVAL_FAILURE;
     }
@@ -312,7 +349,7 @@ int32_t md_sqlite_init(void *ptr, int argc, char *argv[])
     META_PRINT(mws->parent->logfile, "Done configuring SQLite handle\n");
 
     return md_sqlite_configure(mws, db_filename, node_id, interval,
-            num_events, meta_prefix, gps_prefix);
+            num_events, meta_prefix, gps_prefix, monitor_prefix);
 }
 
 static void md_sqlite_handle(struct md_writer *writer, struct md_event *event)
@@ -337,6 +374,14 @@ static void md_sqlite_handle(struct md_writer *writer, struct md_event *event)
         if (!retval)
             mws->num_gps_events++;
         break;
+    case META_TYPE_MUNIN:
+        if (!mws->monitor_prefix[0])
+            return;
+
+        retval = md_sqlite_handle_munin_event(mws, (struct md_munin_event*) event);
+        if (!retval)
+            mws->num_munin_events++;
+        break;
     default:
         META_PRINT(mws->parent->logfile, "SQLite writer does not support event %u\n",
                 event->md_type);
@@ -356,7 +401,7 @@ static void md_sqlite_handle(struct md_writer *writer, struct md_event *event)
     //These two are exclusive. There is no point adding timeout if event_limit
     //is hit. This can happen if event_limit is 1. The reason we do not use
     //lte is that if a copy fails, we deal with that in a timeout
-    if ((mws->num_conn_events + mws->num_gps_events) == mws->db_events) {
+    if ((mws->num_conn_events + mws->num_gps_events + mws->num_munin_events) == mws->db_events) {
         md_sqlite_copy_db(mws, 0);
     } else if (!mws->timeout_added) {
         mde_start_timer(mws->parent->event_loop, mws->timeout_handle,

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -29,7 +29,6 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <libmnl/libmnl.h>
-#include JSON_LOC
 #include <string.h>
 #include <sys/time.h>
 #include <stdlib.h>

--- a/metadata_writer_sqlite.h
+++ b/metadata_writer_sqlite.h
@@ -84,10 +84,6 @@
                             "Timestamp   INTEGER NOT NULL," \
                             "Sequence    INTEGER NOT NULL," \
                             "Boottime    INTEGER NOT NULL," \
-                            "Uptime      INTEGER NOT NULL," \
-                            "MemoryFree  INTEGER," \
-                            "MemoryApps  INTEGER," \
-                            "Temperature REAL," \
                             "PRIMARY KEY(NodeId,Timestamp,Sequence))"
 
 #define INSERT_PROVIDER     "INSERT INTO NetworkEvent(NodeId,Timestamp" \
@@ -110,9 +106,8 @@
                             "VALUES (?,?,?,?,?,?,?,?)"
 
 #define INSERT_MONITOR_EVENT "INSERT INTO MonitorEvents(NodeId,Timestamp" \
-                             ",Sequence,Boottime,Uptime,MemoryFree,MemoryApps" \
-                             ",Temperature) " \
-                             "VALUES (?,?,?,?,?,?,?,?)"
+                             ",Sequence,Boottime) " \
+                             "VALUES (?,?,?,?)"
 
 #define SELECT_LAST_UPDATE  "SELECT EventValueStr FROM NetworkUpdates WHERE "\
                             "L3SessionId=? AND "\
@@ -191,14 +186,10 @@
                             "quote(\"GroundSpeed\"), quote(\"NumOfSatelites\") "\
                             "|| \")\" FROM \"GpsEvents\" ORDER BY Timestamp;"
 
-
 #define DUMP_MONITOR        "SELECT \"REPLACE INTO MonitorEvents" \
-                            "(NodeId,Timestamp,Sequence,Boottime,Uptime" \
-                            ",MemoryFree,MemoryApps,Temperature) VALUES(\" "\
+                            "(NodeId,Timestamp,Sequence,Boottime) VALUES(\" "\
                             "|| quote(\"NodeId\"), quote(\"Timestamp\"), "\
-                            "quote(\"Sequence\"), quote(\"Boottime\"), "\
-                            "quote(\"Uptime\"), quote(\"MemoryFree\"), "\
-                            "quote(\"MemoryApps\"), quote(\"Temperature\") "\
+                            "quote(\"Sequence\"), quote(\"Boottime\") "\
                             "|| \")\" FROM \"MonitorEvents\" ORDER BY Timestamp;"
 
 

--- a/metadata_writer_sqlite.h
+++ b/metadata_writer_sqlite.h
@@ -79,6 +79,17 @@
                             "NumOfSatelites INTEGER," \
                             "PRIMARY KEY(NodeId,Timestamp,Sequence))"
 
+#define CREATE_MONITOR_SQL  "CREATE TABLE IF NOT EXISTS MonitorEvents(" \
+                            "NodeId      INTEGER NOT NULL," \
+                            "Timestamp   INTEGER NOT NULL," \
+                            "Sequence    INTEGER NOT NULL," \
+                            "Boottime    INTEGER NOT NULL," \
+                            "Uptime      INTEGER NOT NULL," \
+                            "MemoryFree  INTEGER," \
+                            "MemoryApps  INTEGER," \
+                            "Temperature REAL," \
+                            "PRIMARY KEY(NodeId,Timestamp,Sequence))"
+
 #define INSERT_PROVIDER     "INSERT INTO NetworkEvent(NodeId,Timestamp" \
                             ",Sequence,L3SessionId,L4SessionId,EventType" \
                             ",EventParam,EventValue,EventValueStr,InterfaceType" \
@@ -97,6 +108,11 @@
                             ",Sequence,Latitude,Longitude,Altitude" \
                             ",GroundSpeed,NumOfSatelites) " \
                             "VALUES (?,?,?,?,?,?,?,?)"
+
+#define INSERT_MONITOR_EVENT "INSERT INTO MonitorEvents(NodeId,Timestamp" \
+                             ",Sequence,Boottime,Uptime,MemoryFree,MemoryApps" \
+                             ",Temperature) " \
+                             "VALUES (?,?,?,?,?,?,?,?)"
 
 #define SELECT_LAST_UPDATE  "SELECT EventValueStr FROM NetworkUpdates WHERE "\
                             "L3SessionId=? AND "\
@@ -125,9 +141,11 @@
                             "NodeId=? "\
                             "WHERE NodeId=0"
 
-#define DELETE_TABLE        "DELETE FROM NetworkEvent"
+#define DELETE_TABLE         "DELETE FROM NetworkEvent"
 
-#define DELETE_GPS_TABLE    "DELETE FROM GpsEvents"
+#define DELETE_GPS_TABLE     "DELETE FROM GpsEvents"
+
+#define DELETE_MONITOR_TABLE "DELETE FROM MonitorEvents"
 
 //This statement is a static version of what the .dump command does. A dynamic
 //version would query the master table to get tables and then PRAGMA to get
@@ -164,12 +182,6 @@
                             "quote(\"NetworkAddress\"),quote(\"NetworkProvider\") || \",Now())\""\
                             "FROM \"NetworkUpdates\" WHERE Timestamp>=? ORDER BY Timestamp;"
 
-#define INSERT_GPS_EVENT    "INSERT INTO GpsEvents(NodeId,Timestamp" \
-                            ",Sequence,Latitude,Longitude,Altitude" \
-                            ",GroundSpeed,NumOfSatelites) " \
-                            "VALUES (?,?,?,?,?,?,?,?)"
-
-
 #define DUMP_GPS            "SELECT \"REPLACE INTO GpsEvents" \
                             "(NodeId,Timestamp,Sequence,Latitude,Longitude" \
                             ",Altitude,GroundSpeed,NumOfSatelites) VALUES(\" "\
@@ -178,6 +190,18 @@
                             "quote(\"Longitude\"), quote(\"Altitude\"), "\
                             "quote(\"GroundSpeed\"), quote(\"NumOfSatelites\") "\
                             "|| \")\" FROM \"GpsEvents\" ORDER BY Timestamp;"
+
+
+#define DUMP_MONITOR        "SELECT \"REPLACE INTO MonitorEvents" \
+                            "(NodeId,Timestamp,Sequence,Boottime,Uptime" \
+                            ",MemoryFree,MemoryApps,Temperature) VALUES(\" "\
+                            "|| quote(\"NodeId\"), quote(\"Timestamp\"), "\
+                            "quote(\"Sequence\"), quote(\"Boottime\"), "\
+                            "quote(\"Uptime\"), quote(\"MemoryFree\"), "\
+                            "quote(\"MemoryApps\"), quote(\"Temperature\") "\
+                            "|| \")\" FROM \"MonitorEvents\" ORDER BY Timestamp;"
+
+
 
 struct md_event;
 struct md_writer;
@@ -194,12 +218,14 @@ struct md_writer_sqlite {
     sqlite3_stmt *last_update;
 
     sqlite3_stmt *insert_gps, *delete_gps, *dump_gps;
+    sqlite3_stmt *insert_monitor, *delete_monitor, *dump_monitor;
 
     uint32_t node_id;
     uint32_t db_interval;
     uint32_t db_events;
     uint32_t num_conn_events;
     uint32_t num_gps_events;
+    uint32_t num_munin_events;
 
     uint8_t timeout_added;
     uint8_t file_failed;
@@ -212,8 +238,8 @@ struct md_writer_sqlite {
     float gps_speed;
 
     struct backend_timeout_handle *timeout_handle;
-    char meta_prefix[128], gps_prefix[128];
-    size_t meta_prefix_len, gps_prefix_len;
+    char   meta_prefix[128], gps_prefix[128], monitor_prefix[128];
+    size_t meta_prefix_len,  gps_prefix_len,  monitor_prefix_len;
 };
 
 void md_sqlite_setup(struct md_exporter *mde, struct md_writer_sqlite* mws);

--- a/metadata_writer_sqlite_monitor.c
+++ b/metadata_writer_sqlite_monitor.c
@@ -1,0 +1,119 @@
+/* Copyright (c) 2015, Celerway, Kristian Evensen <kristrev@celerway.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <sqlite3.h>
+
+#include "metadata_exporter.h"
+#include "metadata_writer_sqlite_monitor.h"
+#include "metadata_writer_sqlite_helpers.h"
+#include "metadata_exporter_log.h"
+
+static uint8_t md_sqlite_monitor_dump_db(struct md_writer_sqlite *mws, FILE *output)
+{
+    sqlite3_reset(mws->dump_monitor);
+    
+    if (md_sqlite_helpers_dump_write(mws->dump_monitor, output))
+        return RETVAL_FAILURE;
+    else
+        return RETVAL_SUCCESS;
+}
+
+uint8_t md_sqlite_monitor_copy_db(struct md_writer_sqlite *mws)
+{
+    uint8_t retval = md_writer_helpers_copy_db(mws->monitor_prefix,
+            mws->monitor_prefix_len, md_sqlite_monitor_dump_db, mws,
+            mws->delete_monitor);
+
+    if (retval == RETVAL_SUCCESS)
+        mws->num_munin_events = 0;
+
+    return retval;
+}
+
+uint8_t md_sqlite_handle_munin_event(struct md_writer_sqlite *mws,
+                                   struct md_munin_event *mme)
+{
+    /*
+     checks: session module is loaded 
+             session.start >> year 1970
+    */
+    json_object *value;
+    int64_t boottime    = 0, uptime = 0;
+    int64_t memoryfree  = 0, memoryapps = 0;
+    double  temperature = 0.0;
+
+    json_object *session_obj;
+    if (!json_object_object_get_ex(mme->json_blob, "session", &session_obj)) {
+        META_PRINT(mws->parent->logfile, "Failed to read data from session module (Munin)\n");
+        return RETVAL_FAILURE;
+    }
+    if (!json_object_object_get_ex(session_obj, "start", &value)) 
+        return RETVAL_FAILURE;
+    if ((boottime = json_object_get_int64(value)) < 1400000000 ) {
+        META_PRINT(mws->parent->logfile, "Failed to read valid start time from session module (Munin): %" PRId64 "\n", boottime);
+        return RETVAL_FAILURE;
+    }
+
+    if (json_object_object_get_ex(session_obj, "current", &value)) 
+      uptime = json_object_get_int64(value);
+
+    json_object *memory_obj;
+    if (json_object_object_get_ex(mme->json_blob, "memory", &memory_obj)) {
+      if (json_object_object_get_ex(memory_obj, "free", &value)) 
+        memoryfree = json_object_get_int64(value);
+      if (json_object_object_get_ex(memory_obj, "apps", &value)) 
+        memoryapps = json_object_get_int64(value);
+    }
+
+    json_object *temp_obj;
+    if (json_object_object_get_ex(mme->json_blob, "temp", &temp_obj)) {
+      if (json_object_object_get_ex(temp_obj, "cpu", &value)) 
+        temperature = json_object_get_double(value);
+    }
+
+    sqlite3_stmt *stmt = mws->insert_monitor;
+    sqlite3_clear_bindings(stmt);
+    sqlite3_reset(stmt);
+
+    if (sqlite3_bind_int(stmt,    1, mws->node_id)  ||
+        sqlite3_bind_int(stmt,    2, mme->tstamp)   ||
+        sqlite3_bind_int(stmt,    3, mme->sequence) || 
+        sqlite3_bind_int64(stmt,  4, boottime)      ||
+        sqlite3_bind_int64(stmt,  5, uptime)        || 
+        sqlite3_bind_int64(stmt,  6, memoryfree)    ||
+        sqlite3_bind_int64(stmt,  7, memoryapps)    ||
+        sqlite3_bind_double(stmt, 8, temperature))  {
+        META_PRINT(mws->parent->logfile, "Failed to bind values to INSERT query (GPS)\n");
+        return RETVAL_FAILURE;
+    }
+
+    if (sqlite3_step(stmt) != SQLITE_DONE)
+        return RETVAL_FAILURE;
+    else
+        return RETVAL_SUCCESS;
+}
+

--- a/metadata_writer_sqlite_monitor.h
+++ b/metadata_writer_sqlite_monitor.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2015, Celerway, Kristian Evensen <kristrev@celerway.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef METADATA_WRITER_SQLITE_MONITOR
+#define METADATA_WRITER_SQLITE_MONITOR
+
+#include "metadata_exporter.h"
+#include "metadata_writer_sqlite.h"
+
+uint8_t md_sqlite_handle_munin_event(struct md_writer_sqlite *mws,
+                                     struct md_munin_event *mge);
+uint8_t md_sqlite_monitor_copy_db(struct md_writer_sqlite *mws);
+
+#endif
+

--- a/metadata_writer_zeromq.c
+++ b/metadata_writer_zeromq.c
@@ -187,7 +187,6 @@ static void md_zeromq_handle_munin(struct md_writer_zeromq *mwz,
    
     //TODO: Error handling
     zmq_send(mwz->zmq_publisher, topic, strlen(topic), 0);
-    json_object_put(mge->json_blob);
 }
 
 

--- a/metadata_writer_zeromq.c
+++ b/metadata_writer_zeromq.c
@@ -177,6 +177,20 @@ static void md_zeromq_handle_gps(struct md_writer_zeromq *mwz,
     json_object_put(gps_obj);
 }
 
+static void md_zeromq_handle_munin(struct md_writer_zeromq *mwz,
+                                   struct md_munin_event *mge)
+{
+    char topic[8192];
+
+    snprintf(topic, sizeof(topic), "MONROE.MONITOR %s", json_object_to_json_string_ext(mge->json_blob, JSON_C_TO_STRING_PLAIN));
+   
+    //TODO: Error handling
+    zmq_send(mwz->zmq_publisher, topic, strlen(topic), 0);
+    json_object_put(mge->json_blob);
+}
+
+
+
 static json_object* md_zeromq_create_json_modem_default(struct md_writer_zeromq *mwz,
                                                         struct md_conn_event *mce)
 {
@@ -294,6 +308,9 @@ static void md_zeromq_handle(struct md_writer *writer, struct md_event *event)
         break;
     case META_TYPE_CONNECTION:
         md_zeromq_handle_conn(mwz, (struct md_conn_event*) event);
+        break;
+    case META_TYPE_MUNIN:
+        md_zeromq_handle_munin(mwz, (struct md_munin_event*) event);
     default:
         break;
     }


### PR DESCRIPTION
Feel free to leave the request open or merge into a branch until this has converged into something we want to use.

Periodically queries a munin-node and reports metadata from selected modules. Plugins can be written in any language, for example C plugins for embedded use, bash scripts for prototyping.

For reference:
- munin-c: https://github.com/munin-monitoring/munin-c
- existing c plugins: https://github.com/munin-monitoring/munin-c/tree/master/src/plugins
- writing plugins: http://munin-monitoring.org/wiki/HowToWritePlugins

e.g.:

```
    ./meta_exporter -m --munin_address=127.0.0.1 --munin_port=4949 -z --zmq_address=127.0.0.1 --zmq_port=5557
    [12:10:36 23/10/2015]: Will configure input 3
    # munin node at monroe-boromir
    [12:10:36 23/10/2015]: Will configure writer 1
    ZeroMQ init done
```

output from ZMQ, with the plugins uptime, cpu and memory activated:

```
    MONROE.MONITOR {"uptime":{"uptime":"3.00"},"cpu":{"user":"3077027","nice":"33261","system":"477321","idle":"47780477","iowait":"220397","irq":"100","softirq":"16558","steal":"0","guest":"0"},"memory":{"apps":"1684492288","free":"381534208","swap":"2809856"}}
```
