### PR TITLE
MONROE.META.NODE.EVENT input and ZMQ writer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,12 @@ if (MUNIN)
     add_definitions("-DMUNIN_SUPPORT")
 endif()
 
+if (SYSEVENT)
+    set(SOURCE ${SOURCE}
+        metadata_input_sysevent.c)
+    add_definitions("-DSYSEVENT_SUPPORT")
+endif()
+
 if (GPS_NSB)
     set(SOURCE ${SOURCE}
         metadata_input_gps_nsb.c)

--- a/metadata_exporter.c
+++ b/metadata_exporter.c
@@ -46,6 +46,9 @@
 #ifdef MUNIN_SUPPORT
     #include "metadata_input_munin.h"
 #endif
+#ifdef SYSEVENT_SUPPORT
+    #include "metadata_input_sysevent.h"
+#endif
 #ifdef NSB_GPS
     #include "metadata_input_gps_nsb.h"
 #endif
@@ -66,6 +69,7 @@
 
 struct md_input_gpsd;
 struct md_input_munin;
+struct md_input_sysevent;
 struct md_writer_sqlite;
 struct md_writer_zeromq;
 
@@ -478,6 +482,9 @@ static void default_usage()
 #ifdef MUNIN_SUPPORT
     fprintf(stderr, "--munin/-m: munin input\n");
 #endif
+#ifdef SYSEVENT_SUPPORT
+    fprintf(stderr, "--sysevent/-y: system ud socket input\n");
+#endif
 #ifdef SQLITE_SUPPORT
     fprintf(stderr, "--sqlite/-s: sqlite writer\n");
 #endif
@@ -538,7 +545,10 @@ int main(int argc, char *argv[])
         {"gpsd",         no_argument,        0,  'g'},
 #endif
 #ifdef MUNIN_SUPPORT
-        {"munin",         no_argument,       0,  'm'},
+        {"munin",        no_argument,        0,  'm'},
+#endif
+#ifdef SYSEVENT_SUPPORT
+        {"sysevent",     no_argument,        0,  'y'},
 #endif
         {"packets",      required_argument,  0,  'p'},
         {"test",         no_argument,        0,  't'},
@@ -628,6 +638,19 @@ int main(int argc, char *argv[])
             num_inputs++;
             break;
 #endif
+#ifdef SYSEVENT_SUPPORT
+        case 'y':
+            mde->md_inputs[MD_INPUT_SYSEVENT] = calloc(sizeof(struct md_input_sysevent), 1);
+
+            if (mde->md_inputs[MD_INPUT_SYSEVENT] == NULL) {
+                META_PRINT(mde->logfile, "Could not allocate Sysevent input\n");
+                exit(EXIT_FAILURE);
+            }
+
+            md_sysevent_setup(mde, (struct md_input_sysevent*) mde->md_inputs[MD_INPUT_SYSEVENT]);
+            num_inputs++;
+            break;
+#endif 
 #ifdef SQLITE_SUPPORT
         case 's':
             mde->md_writers[MD_WRITER_SQLITE] = calloc(sizeof(struct md_writer_sqlite), 1);

--- a/metadata_exporter.h
+++ b/metadata_exporter.h
@@ -44,6 +44,7 @@
 #define META_TYPE_CONNECTION 0x02
 #define META_TYPE_POS        0x04
 #define META_TYPE_MUNIN      0x05
+#define META_TYPE_SYSEVENT   0x06
 
 enum conn_event {
     CONN_EVENT_L3_UP=1,
@@ -77,6 +78,7 @@ enum md_inputs {
     MD_INPUT_GPSD,
     MD_INPUT_GPS_NSB,
     MD_INPUT_MUNIN,
+    MD_INPUT_SYSEVENT,
     __MD_INPUT_MAX
 };
 
@@ -151,6 +153,7 @@ struct md_munin_event {
     int64_t tstamp;
     json_object* json_blob;
 };
+#define md_sysevent md_munin_event
 
 struct md_exporter {
     struct mnl_socket *metadata_sock;

--- a/metadata_input_munin.c
+++ b/metadata_input_munin.c
@@ -242,7 +242,7 @@ static uint8_t md_munin_config(struct md_input_munin *mim,
     }
 }
 
-static uint8_t md_input_munin_destroy(void *ptr) 
+void md_input_munin_destroy(void *ptr) 
 {
     struct md_input_munin *mim = ptr;
     if ((mim != NULL) && (mim->module_count > 0)) { 

--- a/metadata_input_sysevent.c
+++ b/metadata_input_sysevent.c
@@ -47,37 +47,45 @@ static void md_input_sysevent_handle_event(void *ptr, int32_t fd, uint32_t event
     size_t zevents_len = sizeof(zevents);    
     zmq_getsockopt(mis->responder, ZMQ_EVENTS, &zevents, &zevents_len);
 
+    if (!(zevents & ZMQ_POLLIN)) return;
+
+    json_tokener *tok = json_tokener_new();
     do {
-        if (zevents & ZMQ_POLLIN) {
-            int nbytes = zmq_recv(mis->responder, &buffer, 8192, ZMQ_NOBLOCK);
-            if (nbytes<sizeof(buffer)) {
+        int nbytes = zmq_recv(mis->responder, &buffer, 8192, ZMQ_NOBLOCK);
+        if (nbytes>=sizeof(buffer)) break;
                            
-                struct md_sysevent sys_event = {0};
-                struct timeval tv;
-                gettimeofday(&tv, NULL);
+	struct md_sysevent sys_event = {0};
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
 
-                sys_event.md_type   = META_TYPE_SYSEVENT;
-                sys_event.tstamp    = tv.tv_sec;
-                sys_event.sequence  = mde_inc_seq(mis->parent);
+	sys_event.md_type   = META_TYPE_SYSEVENT;
+	sys_event.tstamp    = tv.tv_sec;
+	sys_event.sequence  = mde_inc_seq(mis->parent);
 
-                json_tokener *tok = json_tokener_new();
-                json_object *parsed = json_tokener_parse_ex(tok, buffer, strlen(buffer));
-                if (parsed != NULL) {
-                    zmq_send(mis->responder, "Takk\n", 5, 0);
-                    sys_event.json_blob = parsed;
-                    mde_publish_event_obj(mis->parent, (struct md_event *) &sys_event);
-                    json_object_put(parsed);
-                } else {
-                    enum json_tokener_error jerr = json_tokener_get_error(tok);
-                    fprintf(stderr, "%s (Message was %s)\n", json_tokener_error_desc(jerr), buffer);
-                    zmq_send(mis->responder, "That wasn't JSON.\n", 18, 0);
-                }
-                json_tokener_free(tok);
+	json_object *parsed = json_tokener_parse_ex(tok, buffer, strlen(buffer));
+	json_object *obj_add = NULL;
 
-            }
+	if (parsed == NULL) {
+	    enum json_tokener_error jerr = json_tokener_get_error(tok);
+	    fprintf(stderr, "%s (Message was %s)\n", json_tokener_error_desc(jerr), buffer);
+	    zmq_send(mis->responder, "That wasn't JSON.\n", 18, 0);
+	    break;
         }
+
+	if (!(obj_add = json_object_new_int(sys_event.sequence))) break;
+	json_object_object_add(parsed, "SequenceNumber", obj_add);
+
+	if (!(obj_add = json_object_new_int64(sys_event.tstamp))) break;
+	json_object_object_add(parsed, "Timestamp", obj_add);
+
+        zmq_send(mis->responder, "Takk\n", 5, 0);
+	sys_event.json_blob = parsed;
+        mde_publish_event_obj(mis->parent, (struct md_event *) &sys_event);
+        json_object_put(parsed);
+
         zmq_getsockopt(mis->responder, ZMQ_EVENTS, &zevents, &zevents_len);
     } while (zevents & ZMQ_POLLIN);
+    json_tokener_free(tok);
 }
 
 static uint8_t md_sysevent_config(struct md_input_sysevent *mis)

--- a/metadata_input_sysevent.c
+++ b/metadata_input_sysevent.c
@@ -1,0 +1,118 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/time.h>
+#include <sys/timerfd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <errno.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <zmq.h>
+
+#include "metadata_exporter.h"
+#include "metadata_input_sysevent.h"
+#include "backend_event_loop.h"
+
+/* TODO
+- clean header list 
+*/
+
+static uint8_t md_sysevent_reconnect(struct md_input_sysevent *mis)
+{
+    void *context = zmq_ctx_new();
+    mis->responder = zmq_socket(context, ZMQ_REP);
+
+    int rc = zmq_bind(mis->responder, "ipc:///tmp/sysevent");
+    if (rc != 0) return RETVAL_FAILURE;
+    
+    size_t len=-1;
+    mis->zmq_fd = 0;
+    if (zmq_getsockopt(mis->responder, ZMQ_FD, &(mis->zmq_fd), &len) != 0) { 
+        fprintf(stderr, "zmq_getsockopt failed to get file descriptor.\n");
+        return RETVAL_FAILURE;
+    }
+    return RETVAL_SUCCESS;
+}
+
+static void md_input_sysevent_handle_event(void *ptr, int32_t fd, uint32_t events)
+{
+    struct md_input_sysevent *mis = ptr;
+    char buffer[8192] = {0};
+
+    int zevents = 0;
+    size_t zevents_len = sizeof(zevents);    
+    zmq_getsockopt(mis->responder, ZMQ_EVENTS, &zevents, &zevents_len);
+
+    do {
+        if (zevents & ZMQ_POLLIN) {
+            int nbytes = zmq_recv(mis->responder, &buffer, 8192, ZMQ_NOBLOCK);
+            if (nbytes<sizeof(buffer)) {
+                           
+                struct md_sysevent sys_event = {0};
+                struct timeval tv;
+                gettimeofday(&tv, NULL);
+
+                sys_event.md_type   = META_TYPE_SYSEVENT;
+                sys_event.tstamp    = tv.tv_sec;
+                sys_event.sequence  = mde_inc_seq(mis->parent);
+
+                json_tokener *tok = json_tokener_new();
+                json_object *parsed = json_tokener_parse_ex(tok, buffer, strlen(buffer));
+                if (parsed != NULL) {
+                    zmq_send(mis->responder, "Takk\n", 5, 0);
+                    sys_event.json_blob = parsed;
+                    mde_publish_event_obj(mis->parent, (struct md_event *) &sys_event);
+                    json_object_put(parsed);
+                } else {
+                    enum json_tokener_error jerr = json_tokener_get_error(tok);
+                    fprintf(stderr, "%s (Message was %s)\n", json_tokener_error_desc(jerr), buffer);
+                    zmq_send(mis->responder, "That wasn't JSON.\n", 18, 0);
+                }
+                json_tokener_free(tok);
+
+            }
+        }
+        zmq_getsockopt(mis->responder, ZMQ_EVENTS, &zevents, &zevents_len);
+    } while (zevents & ZMQ_POLLIN);
+}
+
+static uint8_t md_sysevent_config(struct md_input_sysevent *mis)
+{
+    if (md_sysevent_reconnect(mis) == RETVAL_SUCCESS) {
+      if(!(mis->event_handle = backend_create_epoll_handle(
+                               mis, mis->zmq_fd , md_input_sysevent_handle_event)))
+        return RETVAL_FAILURE;
+
+      backend_event_loop_update(
+          mis->parent->event_loop, EPOLLIN, EPOLL_CTL_ADD, mis->zmq_fd, mis->event_handle);
+        
+      return RETVAL_SUCCESS;
+    } 
+    return RETVAL_FAILURE;
+}
+
+static uint8_t md_input_sysevent_init(void *ptr, int argc, char *argv[])
+{
+    struct md_input_sysevent *mis = ptr;
+    return md_sysevent_config(mis);
+}
+
+static void md_input_sysevent_usage()
+{
+}
+
+static void md_input_sysevent_destroy()
+{
+}
+
+void md_sysevent_setup(struct md_exporter *mde, struct md_input_sysevent *mis)
+{
+    mis->parent  = mde;
+    mis->init    = md_input_sysevent_init;
+    mis->destroy = md_input_sysevent_destroy;
+    mis->usage   = md_input_sysevent_usage;
+}

--- a/metadata_input_sysevent.h
+++ b/metadata_input_sysevent.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <uv.h>
+
+#include "metadata_exporter.h"
+
+struct backend_epoll_handle;
+
+struct md_input_sysevent {
+    MD_INPUT;
+    struct backend_epoll_handle *event_handle;
+    void* responder;
+    char* message;
+    int zmq_fd;
+};
+
+void md_sysevent_setup(struct md_exporter *mde, struct md_input_sysevent *mis);

--- a/metadata_writer_zeromq.c
+++ b/metadata_writer_zeromq.c
@@ -283,8 +283,10 @@ static void md_zeromq_handle(struct md_writer *writer, struct md_event *event)
         break;
     case META_TYPE_MUNIN:
         md_zeromq_handle_munin(mwz, (struct md_munin_event*) event);
+        break;
     case META_TYPE_SYSEVENT:
         md_zeromq_handle_sysevent(mwz, (struct md_sysevent*) event);
+        break;
     default:
         break;
     }

--- a/metadata_writer_zeromq.c
+++ b/metadata_writer_zeromq.c
@@ -121,7 +121,6 @@ static void md_zeromq_handle_gps(struct md_writer_zeromq *mwz,
 {
     char topic[8192];
     struct json_object *gps_obj = md_zeromq_create_json_gps(mwz, mge);
-    int retval;
 
     if (gps_obj == NULL) {
         META_PRINT(mwz->parent->logfile, "Failed to create GPS ZMQ JSON\n");
@@ -146,6 +145,17 @@ static void md_zeromq_handle_munin(struct md_writer_zeromq *mwz,
       zmq_send(mwz->zmq_publisher, topic, strlen(topic), 0);
     }
 }
+
+
+static void md_zeromq_handle_sysevent(struct md_writer_zeromq *mwz,
+                                   struct md_sysevent *mge)
+{
+    char topic[8192];
+
+    snprintf(topic, sizeof(topic), "MONROE.META.NODE.EVENT %s",json_object_to_json_string_ext(mge->json_blob, JSON_C_TO_STRING_PLAIN));
+    zmq_send(mwz->zmq_publisher, topic, strlen(topic), 0);
+}
+
 
 
 
@@ -271,6 +281,8 @@ static void md_zeromq_handle(struct md_writer *writer, struct md_event *event)
         break;
     case META_TYPE_MUNIN:
         md_zeromq_handle_munin(mwz, (struct md_munin_event*) event);
+    case META_TYPE_SYSEVENT:
+        md_zeromq_handle_sysevent(mwz, (struct md_sysevent*) event);
     default:
         break;
     }


### PR DESCRIPTION
This opens an IPC socket at /tmp/sysevent to receive arbitrary messages via ZMQ/JSON.
These are then validated (parsed) and republished as metadata to ZMQ with the topic MONROE.META.NODE.EVENT. 
We should probably add tstamp and seq for consistency with the other message types.

e.g. 

```
MONROE.META.NODE.EVENT {"message":"Hello World 5"}
MONROE.META.NODE.EVENT {"message":"Hello World 6"}
MONROE.META.NODE.EVENT {"message":"Hello World 7"}
```
