### PR TITLE
Store timestamp of last connection dump

### DIFF
--- a/metadata_exporter.c
+++ b/metadata_exporter.c
@@ -224,11 +224,13 @@ static struct json_object *create_fake_conn_obj(uint64_t l3_id, uint64_t l4_id,
 	struct json_object *obj = NULL, *obj_add = NULL;
     uint8_t rand_value = 0;
     uint64_t rand_value_64 = 0;
+    struct timeval tv;
 
 	if (!(obj = json_object_new_object()))
 		return NULL;
 
-	if (!(obj_add = json_object_new_int64((int64_t) tstamp))) {
+    gettimeofday(&tv, NULL);
+	if (!(obj_add = json_object_new_int64(tv.tv_sec))) {
         json_object_put(obj);
         return NULL;
     }
@@ -541,16 +543,16 @@ static void test_netlink(uint32_t packets)
     //TODO: Specify number of packets from command line
     while(1) {
         gettimeofday(&tv, NULL);
-#if 0
+
         if (i == 0)
             obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_META_UPDATE, "1,2,1,", i+1);
         else
             obj_to_send = create_fake_conn_obj(2, 3, CONN_EVENT_META_UPDATE, "1,2,1,4", i+1);
-#endif
+
         /*if (i < 4)
             obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_L3_UP, "1,2,1", i+1);
-        else*/
-            obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_DATA_USAGE_UPDATE, "1,2,1,4", tv.tv_sec);
+        else
+            obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_DATA_USAGE_UPDATE, "1,2,1,4", tv.tv_sec);*/
 
         if (!obj_to_send)
             continue;

--- a/metadata_exporter.c
+++ b/metadata_exporter.c
@@ -539,15 +539,17 @@ static void test_netlink(uint32_t packets)
     //
     //When testing, there is no need to multicast. We can just send to the PID
     netlink_addr.nl_pid = getpid();
+    
+    srand(time(NULL));
 
     //TODO: Specify number of packets from command line
     while(1) {
         gettimeofday(&tv, NULL);
 
         if (i == 0)
-            obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_META_UPDATE, "1,2,1,", i+1);
+            obj_to_send = create_fake_conn_obj(0, 0, CONN_EVENT_META_UPDATE, "1,2,1,", i+1);
         else
-            obj_to_send = create_fake_conn_obj(2, 3, CONN_EVENT_META_UPDATE, "1,2,1,4", i+1);
+            obj_to_send = create_fake_conn_obj(0, 0, CONN_EVENT_META_UPDATE, "1,2,1,4", i+1);
 
         /*if (i < 4)
             obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_L3_UP, "1,2,1", i+1);

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -403,7 +403,8 @@ static int md_sqlite_configure(struct md_writer_sqlite *mws,
                 &(mws->session_id_multip));
 
     if (mws->last_conn_tstamp_path)
-        system_helpers_read_uint_from_file(mws->last_conn_tstamp_path, &(mws->dump_tstamp));
+        system_helpers_read_uint64_from_file(mws->last_conn_tstamp_path,
+                &(mws->dump_tstamp));
 
     return RETVAL_SUCCESS;
 }
@@ -515,7 +516,7 @@ static uint8_t md_sqlite_check_valid_tstamp(struct md_writer_sqlite *mws)
         return RETVAL_FAILURE;
 
     //read uptime
-    if (system_helpers_read_uint_from_file("/proc/uptime", &uptime))
+    if (system_helpers_read_uint64_from_file("/proc/uptime", &uptime))
         return RETVAL_FAILURE;
 
     real_boot_time = tv.tv_sec - uptime;

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -268,7 +268,7 @@ static sqlite3* md_sqlite_configure_db(struct md_writer_sqlite *mws, const char 
 }
 
 static int md_sqlite_configure(struct md_writer_sqlite *mws,
-        const char *db_filename, uint32_t node_id, char* nodeid_file, uint32_t db_interval,
+        const char *db_filename, uint32_t node_id, const char* nodeid_file, uint32_t db_interval,
         uint32_t db_events, const char *meta_prefix, const char *gps_prefix,
         const char *monitor_prefix, const char *usage_prefix)
 {
@@ -290,6 +290,7 @@ static int md_sqlite_configure(struct md_writer_sqlite *mws,
     mws->db_interval = db_interval;
     mws->db_events = db_events;
     mws->do_fake_updates = 1;
+    mws->delete_conn_update = 1;
     
     //We will not use timer right away
     if(!(mws->timeout_handle = backend_event_loop_create_timeout(0,
@@ -554,7 +555,7 @@ static uint8_t md_sqlite_check_session_id(struct md_writer_sqlite *mws)
 
     free(mws->session_id_file);
 
-    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "Session ID values: %llu %llu\n",
+    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "Session ID values: %"PRIu64" %"PRIu64"\n",
             mws->session_id, mws->session_id_multip);
 
     return RETVAL_SUCCESS;

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -402,6 +402,9 @@ static int md_sqlite_configure(struct md_writer_sqlite *mws,
         system_helpers_read_session_id(mws->session_id_file, &(mws->session_id),
                 &(mws->session_id_multip));
 
+    if (mws->last_conn_tstamp_path)
+        system_helpers_read_uint_from_file(mws->last_conn_tstamp_path, &(mws->dump_tstamp));
+
     return RETVAL_SUCCESS;
 }
 
@@ -419,6 +422,7 @@ void md_sqlite_usage()
     fprintf(stderr, "  \"events\":\t\tnumber of events before copying database (default: 10)\n");
     fprintf(stderr, "  \"session_id\":\t\tpath to session id file\n");
     fprintf(stderr, "  \"api_version\":\tbackend API version (default: 1)\n");
+    fprintf(stderr, "  \"last_conn_tstamp_path\":\toptional path to file where we read/store timestamp of last conn dump\n");
     fprintf(stderr, "}\n");
 }
 
@@ -454,6 +458,8 @@ int32_t md_sqlite_init(void *ptr, json_object* config)
                 mws->session_id_file = strdup(json_object_get_string(val));
             else if (!strcmp(key, "api_version"))
                 mws->api_version = (uint32_t) json_object_get_int(val);
+            else if (!strcmp(key, "last_conn_tstamp_path"))
+                mws->last_conn_tstamp_path = strdup(json_object_get_string(val));
         }
     }
 

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -509,7 +509,7 @@ static uint8_t md_sqlite_check_valid_tstamp(struct md_writer_sqlite *mws)
         return RETVAL_FAILURE;
 
     //read uptime
-    if (system_helpers_read_uptime(&uptime))
+    if (system_helpers_read_uint_from_file("/proc/uptime", &uptime))
         return RETVAL_FAILURE;
 
     real_boot_time = tv.tv_sec - uptime;

--- a/metadata_writer_sqlite.h
+++ b/metadata_writer_sqlite.h
@@ -304,6 +304,7 @@ struct md_writer_sqlite {
     sqlite3_stmt *insert_usage, *update_usage, *dump_usage, *delete_usage;
 
     const char *session_id_file;
+    const char *last_conn_tstamp_path;
 
     uint32_t node_id;
     uint32_t db_interval;

--- a/metadata_writer_sqlite.h
+++ b/metadata_writer_sqlite.h
@@ -186,6 +186,8 @@
 
 #define DELETE_TABLE         "DELETE FROM NetworkEvent"
 
+#define DELETE_NW_UPDATE     "DELETE FROM NetworkUpdates WHERE Timestamp < ?"
+
 #define DELETE_GPS_TABLE     "DELETE FROM GpsUpdate"
 
 #define DELETE_MONITOR_TABLE "DELETE FROM MonitorEvents"
@@ -303,7 +305,7 @@ struct md_writer_sqlite {
 
     sqlite3_stmt *insert_usage, *update_usage, *dump_usage, *delete_usage;
 
-    const char *session_id_file;
+    char *session_id_file;
     const char *last_conn_tstamp_path;
 
     uint32_t node_id;
@@ -337,6 +339,7 @@ struct md_writer_sqlite {
     size_t meta_prefix_len,  gps_prefix_len,  monitor_prefix_len, usage_prefix_len;
 
     uint8_t api_version;
+    uint8_t delete_conn_update;
 };
 
 void md_sqlite_usage();

--- a/metadata_writer_sqlite_conn.c
+++ b/metadata_writer_sqlite_conn.c
@@ -557,6 +557,10 @@ uint8_t md_sqlite_conn_copy_db(struct md_writer_sqlite *mws)
     if (retval == RETVAL_SUCCESS) {
         mws->dump_tstamp = mws->last_msg_tstamp;
         mws->num_conn_events = 0;
+
+        if (mws->last_conn_tstamp_path)
+            system_helpers_write_uint64_to_file(mws->last_conn_tstamp_path,
+                    mws->dump_tstamp);
     }
 
     return retval;

--- a/metadata_writer_sqlite_conn.c
+++ b/metadata_writer_sqlite_conn.c
@@ -450,8 +450,10 @@ static uint8_t md_sqlite_handle_update_event(struct md_writer_sqlite *mws,
         md_sqlite_insert_fake_events(mws, mce, retval);
 
     //No need to do UPDATE if INSERT was successful
-    if (retval == SQLITE_DONE)
+    if (retval == SQLITE_DONE) {
+        mws->num_conn_events++;
         return RETVAL_SUCCESS;
+    }
 
     //Update in update table
     retval = md_sqlite_update_event(mws, mce);

--- a/metadata_writer_sqlite_conn.c
+++ b/metadata_writer_sqlite_conn.c
@@ -569,10 +569,8 @@ uint8_t md_sqlite_conn_usage_copy_db(struct md_writer_sqlite *mws)
             mws->usage_prefix_len, md_sqlite_usage_dump_db, mws,
             mws->delete_usage);
    
-    if (retval == RETVAL_SUCCESS) {
-        mws->dump_tstamp = mws->last_msg_tstamp;
+    if (retval == RETVAL_SUCCESS)
         mws->num_usage_events = 0;
-    }
 
     return retval;
 }

--- a/metadata_writer_sqlite_helpers.h
+++ b/metadata_writer_sqlite_helpers.h
@@ -33,10 +33,11 @@
 struct md_writer_sqlite;
 
 typedef uint8_t (*dump_db_cb)(struct md_writer_sqlite *mws, FILE *output);
+typedef uint8_t (*delete_db_cb)(struct md_writer_sqlite *mws);
 
 uint8_t md_writer_helpers_copy_db(char *prefix, size_t prefix_len,
         dump_db_cb dump_db, struct md_writer_sqlite *mws,
-        sqlite3_stmt *delete_stmt);
+        delete_db_cb delete_cb);
 
 uint8_t md_sqlite_helpers_dump_write(sqlite3_stmt *stmt, FILE *output);
 

--- a/metadata_writer_sqlite_monitor.c
+++ b/metadata_writer_sqlite_monitor.c
@@ -43,11 +43,26 @@ static uint8_t md_sqlite_monitor_dump_db(struct md_writer_sqlite *mws, FILE *out
         return RETVAL_SUCCESS;
 }
 
+static uint8_t md_sqlite_monitor_delete_db(struct md_writer_sqlite *mws)
+{
+    int32_t retval = 0;
+    sqlite3_reset(mws->delete_monitor);
+
+    retval = sqlite3_step(mws->delete_monitor);
+
+    if (retval == SQLITE_DONE) {
+        return RETVAL_SUCCESS;
+    } else {
+        META_PRINT_SYSLOG(mws->parent, LOG_ERR, "Failed to delete monitor table\n");
+        return RETVAL_FAILURE;
+    }
+}
+
 uint8_t md_sqlite_monitor_copy_db(struct md_writer_sqlite *mws)
 {
     uint8_t retval = md_writer_helpers_copy_db(mws->monitor_prefix,
             mws->monitor_prefix_len, md_sqlite_monitor_dump_db, mws,
-            mws->delete_monitor);
+            md_sqlite_monitor_delete_db);
 
     if (retval == RETVAL_SUCCESS)
         mws->num_munin_events = 0;

--- a/system_helpers.c
+++ b/system_helpers.c
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <inttypes.h>
 
 #ifdef OPENWRT
 #include <uci.h>
@@ -136,7 +137,7 @@ uint8_t system_helpers_read_uint_from_file(const char *filename,
     if (!file_to_read)
         return RETVAL_FAILURE;
 
-    retval = fscanf(file_to_read, "%llu", value);
+    retval = fscanf(file_to_read, "%"PRIu64, value);
     fclose(file_to_read);
 
     if (retval != 1 || retval == EOF)
@@ -154,14 +155,13 @@ uint8_t system_helpers_read_session_id(const char *path, uint64_t *session_id,
     if (!session_id_file)
         return RETVAL_FAILURE;
 
-    retval = fscanf(session_id_file, "%llu %llu", session_id,
+    retval = fscanf(session_id_file, "%"PRIu64" %"PRIu64, session_id,
             session_id_multip);
     fclose(session_id_file);
 
-    if (retval != 2) {
-        printf("Missin values\n");
+    if (retval != 2)
         return RETVAL_FAILURE;
-    } else
+    else
         return RETVAL_SUCCESS;
 }
 

--- a/system_helpers.c
+++ b/system_helpers.c
@@ -146,6 +146,27 @@ uint8_t system_helpers_read_uint64_from_file(const char *filename,
     return RETVAL_SUCCESS;
 }
 
+uint8_t system_helpers_write_uint64_to_file(const char *filename,
+        uint64_t value)
+{
+    //The only user (so far) of this function only uses this value for help.
+    //Thus, it is not critical if writing fails. Therefore, no need to write to
+    //partial first, link, etc.
+    FILE *file_to_write = fopen(filename, "w");
+    int retval;
+
+    if (!file_to_write)
+        return RETVAL_FAILURE;
+
+    retval = fprintf(file_to_write, "%"PRIu64, value);
+    fclose(file_to_write);
+
+    if (retval < 0)
+        return RETVAL_FAILURE;
+    else
+        return RETVAL_SUCCESS;
+}
+
 uint8_t system_helpers_read_session_id(const char *path, uint64_t *session_id,
         uint64_t *session_id_multip)
 {

--- a/system_helpers.c
+++ b/system_helpers.c
@@ -127,16 +127,17 @@ uint8_t system_helpers_check_address(const char *addr)
 }
 
 //Reads uptime and stores value in uptime.
-uint8_t system_helpers_read_uptime(uint64_t *uptime)
+uint8_t system_helpers_read_uint_from_file(const char *filename,
+        uint64_t *value)
 {
-    FILE *uptime_file = fopen("/proc/uptime", "r");
+    FILE *file_to_read = fopen(filename, "r");
     int retval;
 
-    if (!uptime_file)
+    if (!file_to_read)
         return RETVAL_FAILURE;
 
-    retval = fscanf(uptime_file, "%llu", uptime);
-    fclose(uptime_file);
+    retval = fscanf(file_to_read, "%llu", value);
+    fclose(file_to_read);
 
     if (retval != 1 || retval == EOF)
         return RETVAL_FAILURE;

--- a/system_helpers.c
+++ b/system_helpers.c
@@ -128,7 +128,7 @@ uint8_t system_helpers_check_address(const char *addr)
 }
 
 //Reads uptime and stores value in uptime.
-uint8_t system_helpers_read_uint_from_file(const char *filename,
+uint8_t system_helpers_read_uint64_from_file(const char *filename,
         uint64_t *value)
 {
     FILE *file_to_read = fopen(filename, "r");

--- a/system_helpers.c
+++ b/system_helpers.c
@@ -76,7 +76,7 @@ uint32_t system_helpers_get_nodeid()
     return (uint32_t) node_id;
 }
 #elif MONROE
-uint32_t system_helpers_get_nodeid(char* nodeid_file)
+uint32_t system_helpers_get_nodeid(const char* nodeid_file)
 {
     char num_buf[255];
     long node_id;

--- a/system_helpers.h
+++ b/system_helpers.h
@@ -38,7 +38,7 @@ uint32_t system_helpers_get_nodeid(char* nodeid_file);
 #endif
 
 uint8_t system_helpers_check_address(const char *addr);
-uint8_t system_helpers_read_uint_from_file(const char *path, uint64_t *value);
+uint8_t system_helpers_read_uint64_from_file(const char *path, uint64_t *value);
 uint8_t system_helpers_read_session_id(const char *path, uint64_t *session_id,
         uint64_t *session_id_multip);
 

--- a/system_helpers.h
+++ b/system_helpers.h
@@ -34,12 +34,14 @@
 
 uint32_t system_helpers_get_nodeid();
 #else
-uint32_t system_helpers_get_nodeid(char* nodeid_file);
+uint32_t system_helpers_get_nodeid(const char *nodeid_file);
 #endif
 
 uint8_t system_helpers_check_address(const char *addr);
 uint8_t system_helpers_read_uint64_from_file(const char *path, uint64_t *value);
 uint8_t system_helpers_read_session_id(const char *path, uint64_t *session_id,
         uint64_t *session_id_multip);
+uint8_t system_helpers_write_uint64_to_file(const char *filename,
+        uint64_t value);
 
 #endif

--- a/system_helpers.h
+++ b/system_helpers.h
@@ -38,7 +38,7 @@ uint32_t system_helpers_get_nodeid(char* nodeid_file);
 #endif
 
 uint8_t system_helpers_check_address(const char *addr);
-uint8_t system_helpers_read_uptime(uint64_t *uptime);
+uint8_t system_helpers_read_uint_from_file(const char *path, uint64_t *value);
 uint8_t system_helpers_read_session_id(const char *path, uint64_t *session_id,
         uint64_t *session_id_multip);
 


### PR DESCRIPTION
We have tried to be smart by only storing events and then using a keep-alive message to indicate that connection is still alive. This keep-alive message is kept in the database also across restarts of metadata expoter, since the exporter might crash and the tool exporting connection events not. For nodes/routers that are switched on for a long time, the database might contain a large number of these keep-alive messages.

This caused problems when the exporter crashed and the first dump was made, as all the old updates were also written to file. The problem was made worse by the concatenating feature used on the Monroe nodes + a bug which caused the exporter to crash frequently. The sql file to be transferred to the server only grew bigger and bigger for each. 

This PR introduces support for storing the timestamp of the last message written to the database to file. This file, if specified, is read by exporter on start and is used as a guard in the update query. We also delete updates that have not been updated for the last 30 min. This might cause us to generate some redundant fake events, but it is worth it to keep table size down.
