### PR TITLE
bump data version

### DIFF
--- a/metadata_writer_zeromq.h
+++ b/metadata_writer_zeromq.h
@@ -31,7 +31,7 @@
 #include "metadata_exporter.h"
 
 #define MD_ZMQ_BIND_INTVL   1000
-#define MD_ZMQ_DATA_VERSION 1
+#define MD_ZMQ_DATA_VERSION 3
 
 enum md_zmq_topics {
     MD_ZMQ_TOPIC_SYSEVENT,


### PR DESCRIPTION
DataVersion was 2 in MONROE-PROJECT before, with the new field names it should be bumped to 3.