### PR TITLE
Fix pointer misdirection in netlink GPS input.

### DIFF
--- a/metadata_input_netlink.c
+++ b/metadata_input_netlink.c
@@ -209,7 +209,7 @@ static void md_input_netlink_handle_gps_event(struct md_input_netlink *min,
     if (!event)
         return;
 
-    mde_publish_event_obj(min->parent, (struct md_event *) &event);
+    mde_publish_event_obj(min->parent, (struct md_event *) event);
     free(event);
 }
 

--- a/metadata_writer_zeromq.c
+++ b/metadata_writer_zeromq.c
@@ -969,6 +969,8 @@ static void md_zeromq_writer_handle_radio(struct md_writer_zeromq *mwz,
                 (struct md_radio_grr_cell_resel_event*) mre);
         break;
     default:
+        META_PRINT_SYSLOG(mwz->parent, LOG_INFO, "ZMQ writer does not support event %u\n",
+                                    mre->md_type);  
         break;
 
     }
@@ -1021,6 +1023,8 @@ static void md_zeromq_writer_handle(struct md_writer *writer, struct md_event *e
         md_zeromq_writer_handle_radio(mwz, (struct md_radio_event*) event);
         break;
     default:
+        META_PRINT_SYSLOG(mwz->parent, LOG_INFO, "ZMQ writer does not support event %u\n",
+                                    event->md_type);  
         break;
     }
 }


### PR DESCRIPTION
gps_events from netlink JSON are currently overwritten by a spurious reference.