### PR TITLE
bump version number due to broken file ownerships in build process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 import java.text.SimpleDateFormat
 jobName = "metadata-exporter"
-version = "0.1.46"
+version = "0.1.47"
 build_dir = "build"
 buildPackageName = "meta-exporter"
 


### PR DESCRIPTION
Jenkins built debian packages with user permissions, this is fixed now, but we should bump the version numbers to force an update on staging nodes.