### PR TITLE
Remove epoch assumption

### DIFF
--- a/metadata_exporter.c
+++ b/metadata_exporter.c
@@ -262,7 +262,6 @@ static struct json_object *create_fake_restart_obj()
     return obj;
 }
 
-#if 0
 static struct json_object *create_fake_conn_obj(uint64_t l3_id, uint64_t l4_id,
         uint8_t event_param, char *event_value_str, uint64_t tstamp)
 {
@@ -412,7 +411,6 @@ static struct json_object *create_fake_conn_obj(uint64_t l3_id, uint64_t l4_id,
 
 	return obj;	
 }
-#endif
 
 static ssize_t send_netlink_json(uint8_t *snd_buf,
         struct json_object *parsed_obj, int32_t sock_fd,
@@ -595,14 +593,14 @@ static void test_netlink(uint32_t packets)
         /*if (i == 0)
             obj_to_send = create_fake_conn_obj(0, 0, CONN_EVENT_META_UPDATE, "1,2,1,", i+1);
         else
-            obj_to_send = create_fake_conn_obj(0, 0, CONN_EVENT_META_UPDATE, "1,2,1,4", i+1);*/
+            obj_to_send = create_fake_conn_obj(0, 0, CONN_EVENT_META_UPDATE, "1,2,1,4", i+1);
 
-        /*if (i < 4)
+        if (i < 4)
             obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_L3_UP, "1,2,1", i+1);
         else
             obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_DATA_USAGE_UPDATE, "1,2,1,4", tv.tv_sec);*/
 
-        obj_to_send = create_fake_restart_obj();
+        //obj_to_send = create_fake_restart_obj();
 
         if (!obj_to_send)
             continue;

--- a/metadata_exporter.c
+++ b/metadata_exporter.c
@@ -590,7 +590,7 @@ static void test_netlink(uint32_t packets)
     while(1) {
         gettimeofday(&tv, NULL);
 
-        /*if (i == 0)
+        if (i == 0)
             obj_to_send = create_fake_conn_obj(0, 0, CONN_EVENT_META_UPDATE, "1,2,1,", i+1);
         else
             obj_to_send = create_fake_conn_obj(0, 0, CONN_EVENT_META_UPDATE, "1,2,1,4", i+1);
@@ -598,7 +598,7 @@ static void test_netlink(uint32_t packets)
         if (i < 4)
             obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_L3_UP, "1,2,1", i+1);
         else
-            obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_DATA_USAGE_UPDATE, "1,2,1,4", tv.tv_sec);*/
+            obj_to_send = create_fake_conn_obj(1, 2, CONN_EVENT_DATA_USAGE_UPDATE, "1,2,1,4", tv.tv_sec);
 
         //obj_to_send = create_fake_restart_obj();
 

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -308,7 +308,7 @@ static int md_sqlite_read_boot_time(struct md_writer_sqlite *mws, uint64_t *boot
     }
 
     *boot_time = tv.tv_sec - uptime;
-    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "%lu %lu %lu\n", *boot_time, tv.tv_sec, uptime);
+    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "%" PRIu64 "%" PRIu64 "%" PRIu64 "\n", *boot_time, tv.tv_sec, uptime);
     return RETVAL_SUCCESS;
 }
 
@@ -610,7 +610,7 @@ static uint8_t md_sqlite_check_valid_tstamp(struct md_writer_sqlite *mws)
         return RETVAL_FAILURE;
     }
 
-    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "Real boot %lu orig boot %lu\n", real_boot_time, mws->orig_boot_time);
+    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "Real boot %" PRIu64 " orig boot %" PRIu64 "\n", real_boot_time, mws->orig_boot_time);
 
     if (md_sqlite_update_timestamp_db(mws, UPDATE_EVENT_TSTAMP,
                 mws->orig_boot_time, real_boot_time) ||

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -300,14 +300,16 @@ static int md_sqlite_read_boot_time(struct md_writer_sqlite *mws, uint64_t *boot
 {
     struct timeval tv;
     uint64_t uptime;
-    gettimeofday(&tv, NULL);
 
     //read uptime
     if (system_helpers_read_uint64_from_file("/proc/uptime", &uptime)) {
         return RETVAL_FAILURE;
     }
 
+    gettimeofday(&tv, NULL);
+
     *boot_time = tv.tv_sec - uptime;
+    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "%" PRIu64 " %ld %" PRIu64 "\n", *boot_time, tv.tv_sec, uptime);
     return RETVAL_SUCCESS;
 }
 

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -308,7 +308,6 @@ static int md_sqlite_read_boot_time(struct md_writer_sqlite *mws, uint64_t *boot
     }
 
     *boot_time = tv.tv_sec - uptime;
-    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "%" PRIu64 " %ld %" PRIu64 "\n", *boot_time, tv.tv_sec, uptime);
     return RETVAL_SUCCESS;
 }
 

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -296,7 +296,7 @@ static sqlite3* md_sqlite_configure_db(struct md_writer_sqlite *mws, const char 
     return db_handle;
 }
 
-static int md_sqlite_read_boot_time(uint64_t *boot_time)
+static int md_sqlite_read_boot_time(struct md_writer_sqlite *mws, uint64_t *boot_time)
 {
     struct timeval tv;
     uint64_t uptime;
@@ -308,6 +308,7 @@ static int md_sqlite_read_boot_time(uint64_t *boot_time)
     }
 
     *boot_time = tv.tv_sec - uptime;
+    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "%lu %lu %lu\n", *boot_time, tv.tv_sec, uptime);
     return RETVAL_SUCCESS;
 }
 
@@ -479,7 +480,7 @@ static int md_sqlite_configure(struct md_writer_sqlite *mws,
         system_helpers_read_uint64_from_file(mws->last_conn_tstamp_path,
                 &(mws->dump_tstamp));
 
-    return md_sqlite_read_boot_time(&(mws->orig_boot_time));
+    return md_sqlite_read_boot_time(mws, &(mws->orig_boot_time));
 }
 
 void md_sqlite_usage()
@@ -605,7 +606,7 @@ static uint8_t md_sqlite_check_valid_tstamp(struct md_writer_sqlite *mws)
     if (mws->ntp_fix_file[0] && access(mws->ntp_fix_file, F_OK))
         return RETVAL_FAILURE;
 
-    if (md_sqlite_read_boot_time(&real_boot_time)) {
+    if (md_sqlite_read_boot_time(mws, &real_boot_time)) {
         return RETVAL_FAILURE;
     }
 

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -309,7 +309,11 @@ static int md_sqlite_read_boot_time(struct md_writer_sqlite *mws, uint64_t *boot
     gettimeofday(&tv, NULL);
 
     *boot_time = tv.tv_sec - uptime;
-    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "%" PRIu64 " %ld %" PRIu64 "\n", *boot_time, tv.tv_sec, uptime);
+    
+    if (*boot_time < mws->orig_boot_time) {
+        return RETVAL_FAILURE;
+    }
+
     return RETVAL_SUCCESS;
 }
 

--- a/metadata_writer_sqlite.c
+++ b/metadata_writer_sqlite.c
@@ -308,7 +308,7 @@ static int md_sqlite_read_boot_time(struct md_writer_sqlite *mws, uint64_t *boot
     }
 
     *boot_time = tv.tv_sec - uptime;
-    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "%" PRIu64 "%" PRIu64 "%" PRIu64 "\n", *boot_time, tv.tv_sec, uptime);
+    META_PRINT_SYSLOG(mws->parent, LOG_INFO, "%" PRIu64 " %ld %" PRIu64 "\n", *boot_time, tv.tv_sec, uptime);
     return RETVAL_SUCCESS;
 }
 

--- a/metadata_writer_sqlite.h
+++ b/metadata_writer_sqlite.h
@@ -36,14 +36,6 @@
 #define MAX_PATH_LEN 128
 #define FAKE_UPDATE_LIMIT 120
 
-//This the first valid timestamp of an event and the value is not randomly
-//chosen, it is the time when this piece of code was written. And
-//since time is never supposed to move backwards ... Note that this check
-//assumes that all nodes will have some offset time lower than this, and
-//then ntp (or something else) will set a correct time. A good starting
-//point is epoch
-#define FIRST_VALID_TIMESTAMP 1455740094
-
 #define CREATE_SQL          "CREATE TABLE IF NOT EXISTS NetworkEvent(" \
                             "NodeId INTEGER NOT NULL," \
                             "SessionId INTEGER NOT NULL," \
@@ -376,7 +368,7 @@ struct md_writer_sqlite {
     uint8_t valid_timestamp;
 
     char meta_prefix[128], gps_prefix[128], monitor_prefix[128],
-        usage_prefix[128], system_prefix[128];
+        usage_prefix[128], system_prefix[128], ntp_fix_file[128];
 
     uint8_t api_version;
     uint8_t delete_conn_update;

--- a/metadata_writer_sqlite.h
+++ b/metadata_writer_sqlite.h
@@ -206,15 +206,15 @@
                             "WHERE NodeId=0"
 
 #define UPDATE_EVENT_TSTAMP "UPDATE NetworkEvent SET " \
-                            "Timestamp = Timestamp + ? "\
+                            "Timestamp = (Timestamp - ?) + ? "\
                             "WHERE Timestamp < ?"
 
 #define UPDATE_UPDATES_TSTAMP     "UPDATE NetworkUpdates SET " \
-                                  "Timestamp = Timestamp + ? "\
+                                  "Timestamp = (Timestamp - ?) + ? "\
                                   "WHERE Timestamp < ?"
 
 #define UPDATE_SYSTEM_TSTAMP     "UPDATE RebootEvent SET " \
-                                  "Timestamp = Timestamp + ? "\
+                                  "Timestamp = (Timestamp - ?) + ? "\
                                   "WHERE Timestamp < ?"
 
 #define UPDATE_EVENT_SESSION_ID "UPDATE NetworkEvent SET "\

--- a/metadata_writer_sqlite.h
+++ b/metadata_writer_sqlite.h
@@ -328,6 +328,7 @@ struct md_writer_sqlite {
     uint64_t dump_tstamp;
     uint64_t last_msg_tstamp;
     uint64_t last_gps_insert;
+    uint64_t orig_boot_time;
 
     //TODO: Consider moving this to the generic writer struct if need be
     //These values keep track of the unique session id (and multiplier), which

--- a/metadata_writer_sqlite.h
+++ b/metadata_writer_sqlite.h
@@ -325,6 +325,21 @@ struct backend_timeout_handle;
 struct md_writer_sqlite {
     MD_WRITER;
 
+    uint64_t dump_tstamp;
+    uint64_t last_msg_tstamp;
+    uint64_t last_gps_insert;
+
+    //TODO: Consider moving this to the generic writer struct if need be
+    //These values keep track of the unique session id (and multiplier), which
+    //are normally assumed to be the boot counter (+ multiplier)
+    uint64_t session_id;
+    uint64_t session_id_multip;
+
+    float gps_speed;
+
+    size_t meta_prefix_len,  gps_prefix_len,  monitor_prefix_len,
+           usage_prefix_len, system_prefix_len;
+
     sqlite3 *db_handle;
 
     sqlite3_stmt *insert_event, *insert_update;
@@ -342,6 +357,8 @@ struct md_writer_sqlite {
     char *session_id_file;
     char *node_id_file;
     const char *last_conn_tstamp_path;
+    struct backend_timeout_handle *timeout_handle;
+    struct timeval first_fake_update;
 
     uint32_t node_id;
     uint32_t db_interval;
@@ -356,25 +373,9 @@ struct md_writer_sqlite {
     uint8_t file_failed;
     uint8_t do_fake_updates;
     uint8_t valid_timestamp;
-    struct timeval first_fake_update;
 
-    uint64_t dump_tstamp;
-    uint64_t last_msg_tstamp;
-    uint64_t last_gps_insert;
-
-    //TODO: Consider moving this to the generic writer struct if need be
-    //These values keep track of the unique session id (and multiplier), which
-    //are normally assumed to be the boot counter (+ multiplier)
-    uint64_t session_id;
-    uint64_t session_id_multip;
-
-    float gps_speed;
-
-    struct backend_timeout_handle *timeout_handle;
     char meta_prefix[128], gps_prefix[128], monitor_prefix[128],
         usage_prefix[128], system_prefix[128];
-    size_t meta_prefix_len,  gps_prefix_len,  monitor_prefix_len,
-           usage_prefix_len, system_prefix_len;
 
     uint8_t api_version;
     uint8_t delete_conn_update;


### PR DESCRIPTION
This commit removes the assumption that time always starts from epoch from the sqlite writer. Instead, we try to estimate the real boot time and original boot time. When we know that we have an ntp fix (currently designed to be signalled by the presence of a file), we update the timestamps in the database for timestamps less than the real boot time. The new timestamp is set to (timestamp - origianl boot time) + real_boot_time. Thus, we get the offset from the original boot time and set the timestamp to offset from the real boot time.

When the time is correct and data exporter starts, we can get into a situation where real boot time is less than original boot time. This will turn the SQL query into a nop, but that is not a problem. The code is meant to handle large jumps in time (like from epoch) and we insert absolute times into the database, so an error of a second is not a problem.